### PR TITLE
Bump CivModCore version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>vg.civcraft.mc.civmodcore</groupId>
 			<artifactId>CivModCore</artifactId>
-			<version>1.6.0</version>
+			<version>1.6.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -129,6 +129,10 @@
 		<repository>
 			<id>spigot-repo</id>
 			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+		</repository>
+		<repository>
+			<id>teal-repo</id>
+			<url>http://dydoisbutts.info:8080/plugin/repository/everything/</url>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Also added Teal's build server because it has the new version of CivModCore. Building the old version is broken because it still uses the broken/unusable stats reporting plugin version.