### PR TITLE
kick player if they have associated with a banned share

### DIFF
--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSShares.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSShares.java
@@ -11,6 +11,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.programmerdan.minecraft.banstick.handler.BanStickEventHandler.doKickWithCheckup;
+
 /**
  * BSShares DAO management object.
  * 
@@ -246,6 +248,15 @@ public final class BSShares {
 		
 		BanStick.getPlugin().info("Found new overlap between {0} and {1}", forPlayer.getName(), player.getName());
 
+		// this happens after the player has already logged in
+		// if the player has been associated with a banned share, kick them
+		final List<BSBan> bans = BSBan.byShare(share, false);
+		if (!bans.isEmpty()) {
+			final BSBan ban = bans.get(0);
+
+			BanStick.getPlugin().info("New overlap between {0} and {1} resulting in at least one ban; kicking...", forPlayer.getName(), player.getName());
+			doKickWithCheckup(player.getUUID(), ban);
+		}
 	}
 	
 	/**

--- a/src/main/java/com/programmerdan/minecraft/banstick/data/BSShares.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/data/BSShares.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.programmerdan.minecraft.banstick.handler.BanHandler.getActivePlayerBanOrTransitive;
 import static com.programmerdan.minecraft.banstick.handler.BanStickEventHandler.doKickWithCheckup;
 
 /**
@@ -250,10 +251,9 @@ public final class BSShares {
 
 		// this happens after the player has already logged in
 		// if the player has been associated with a banned share, kick them
-		final List<BSBan> bans = BSBan.byShare(share, false);
-		if (!bans.isEmpty()) {
-			final BSBan ban = bans.get(0);
-
+		BSBan ban1 = getActivePlayerBanOrTransitive(share.getFirstPlayer().getUUID());
+		BSBan ban = ban1 != null ? ban1 : getActivePlayerBanOrTransitive(share.getSecondPlayer().getUUID());
+		if (ban != null) {
 			BanStick.getPlugin().info("New overlap between {0} and {1} resulting in at least one ban; kicking...", forPlayer.getName(), player.getName());
 			doKickWithCheckup(player.getUUID(), ban);
 		}

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanHandler.java
@@ -336,27 +336,37 @@ public final class BanHandler {
 	/**
 	 * Checks whether a player is banned.
 	 *
-	 * @param player The player UUID to check if banned.
+	 * @param puuid The player UUID to check if banned.
 	 * @return Returns true if the player is banned.
 	 */
-	public static boolean isPlayerBanned(final UUID player) {
-		final BSPlayer bsPlayer = BSPlayer.byUUID(player);
+	public static boolean isPlayerBanned(final UUID puuid) {
+		BSBan ban = getActivePlayerBanOrTransitive(puuid);
+		return ban != null;
+	}
+
+	/**
+	 * Checks whether a player is banned, and returns the ban.
+	 *
+	 * @param puuid The player UUID to check if banned.
+	 * @return Returns true if the player is banned.
+	 */
+	public static BSBan getActivePlayerBanOrTransitive(final UUID puuid) {
+		final BSPlayer bsPlayer = BSPlayer.byUUID(puuid);
 		if (bsPlayer == null) {
-			return false;
+			return null;
 		}
 		final BSBan bsBan = bsPlayer.getBan();
 		if (bsBan != null && !bsBan.hasBanExpired()) {
-			return true;
+			return bsBan;
 		}
 		if (BanStick.getPlugin().getEventHandler().areTransitiveBansEnabled()) {
 			for (final BSPlayer alt : bsPlayer.getTransitiveSharedPlayers(true)) {
 				final BSBan bsAltBan = alt.getBan();
 				if (bsAltBan != null && !bsAltBan.hasBanExpired()) {
-					return true;
+					return bsAltBan;
 				}
 			}
 		}
-		return false;
+		return null;
 	}
-
 }

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
@@ -5,6 +5,7 @@ import com.programmerdan.minecraft.banstick.data.BSBan;
 import com.programmerdan.minecraft.banstick.data.BSIP;
 import com.programmerdan.minecraft.banstick.data.BSIPData;
 import com.programmerdan.minecraft.banstick.data.BSPlayer;
+import com.programmerdan.minecraft.banstick.data.BSSession;
 import com.programmerdan.minecraft.banstick.data.BSShare;
 import java.net.InetAddress;
 import java.util.Collections;

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
@@ -369,19 +369,20 @@ public class BanStickEventHandler implements Listener {
 				// Then do VPN checks
 				if (enableProxyBans || enableProxyKicks) {
 					// Inject IP Hub handler.
-					BanStick.getPlugin().getIPHubHandler().offer(bsPlayer.getLatestSession().getIP());
+					final BSSession latestSession = bsPlayer.getLatestSession();
+					BanStick.getPlugin().getIPHubHandler().offer(latestSession.getIP());
 
 					try {
 						if (bsPlayer.getProxyPardonTime() == null) {
-							if (bsPlayer.getLatestSession().getIP() == null) {
+							if (latestSession.getIP() == null) {
 								BanStick.getPlugin().warning("Weird failure, no ip for {0}", bsPlayer);
 								return;
 							}
-							if (bsPlayer.getLatestSession().getIP().getIPAddress() == null) {
+							if (latestSession.getIP().getIPAddress() == null) {
 								BanStick.getPlugin().warning("Weird failure, no ip address for {0}", bsPlayer);
 								return;
 							}
-							List<BSIPData> proxyChecks = BSIPData.allByIP(bsPlayer.getLatestSession().getIP());
+							List<BSIPData> proxyChecks = BSIPData.allByIP(latestSession.getIP());
 							if (proxyChecks != null) {
 								for (BSIPData proxyCheck : proxyChecks) {
 									// check if entire provider is banned

--- a/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
+++ b/src/main/java/com/programmerdan/minecraft/banstick/handler/BanStickEventHandler.java
@@ -519,7 +519,7 @@ public class BanStickEventHandler implements Listener {
 	 * @param puuid The person to kick
 	 * @param picked The ban being applied
 	 */
-	public void doKickWithCheckup(final UUID puuid, final BSBan picked) {
+	public static void doKickWithCheckup(final UUID puuid, final BSBan picked) {
 		// now schedule a task to kick out the trash.
 		Bukkit.getScheduler().runTask(BanStick.getPlugin(), new Runnable() {
 


### PR DESCRIPTION
@Wingzero54's request:

> Banstick doesn't check a player's associations until after their very first login, and associative bans don't kick you
> [Here](https://github.com/CivClassic/BanStick/blob/master/src/main/java/com/programmerdan/minecraft/banstick/data/BSShares.java#L247) is where it grabs the shares after a player logs in
> I would really like it to follow this action by checking for bans on the associations and banning the player
> Because it's a bit of a loophole that banned players can login an alt and get one free session of gameplay

entirely untested, I could test this on AF creative server if someone can show me how to use banstick commands